### PR TITLE
Fix #24 : Removes white space from the bottom of Sign-in and Sign-up pages

### DIFF
--- a/pages/Signin.vue
+++ b/pages/Signin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main  md:flex  bg-gray-100 md:justify-evenly py-[2rem] px-[0.1rem]" style="height: 100vh">
+  <div class="main  md:flex h-screen bg-gray-100 md:justify-evenly pt-[2rem] px-[0.1rem]">
     <div class="left-panel mt-[5rem] hidden md:block">
       <img src="../assets/37.order-delivered-3.png" class = "w-80 h-80 border-1 border-gray-400 md:order-2" alt="delivery-img">
     </div>

--- a/pages/Signin.vue
+++ b/pages/Signin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main  md:flex  bg-gray-100 md:justify-evenly py-[2rem] px-[0.1rem]">
+  <div class="main  md:flex  bg-gray-100 md:justify-evenly py-[2rem] px-[0.1rem]" style="height: 100vh">
     <div class="left-panel mt-[5rem] hidden md:block">
       <img src="../assets/37.order-delivered-3.png" class = "w-80 h-80 border-1 border-gray-400 md:order-2" alt="delivery-img">
     </div>

--- a/pages/Signup.vue
+++ b/pages/Signup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main  md:flex h-screen bg-gray-100 md:justify-evenly py-[2rem] px-[0.1rem]">
+  <div class="main  md:flex bg-gray-100 md:justify-evenly py-[2rem] px-[0.1rem]">
     <div class="left-panel mt-[6.9rem] hidden md:block">
       <img src="../assets/37.order-delivered-3.png" class = "w-80 h-80 border-1 border-gray-400 md:order-2" alt="delivery-img">
     </div>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24 .
2. This PR does the following: Removes the extra white space at the bottom of the Sign-in page by adding `h-screen` and changing the padding from `py-[2rem]` to `pt-[2rem]`. Also removes the extra white space at the bottom of the Sign-up page by removing `h-screen`.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] The PR is made from a branch that's **not** called "main/master".

## Proof that changes are correct

![Screenshot (26)](https://github.com/bsoc-bitbyte/GetIt/assets/115504480/663890d9-e9bb-4e4f-a8de-bb148c03749f)
![Screenshot (21)](https://github.com/bsoc-bitbyte/GetIt/assets/115504480/27f1eaa8-16d6-4394-86a8-3535ccd04b18)
![Screenshot (23)](https://github.com/bsoc-bitbyte/GetIt/assets/115504480/8b88bdd3-8600-40a7-a8d4-f502cfbc7bb0)
![Screenshot (24)](https://github.com/bsoc-bitbyte/GetIt/assets/115504480/7c509a65-c493-4915-a8c3-ac22197410a4)
![Screenshot (22)](https://github.com/bsoc-bitbyte/GetIt/assets/115504480/300b8e36-ed4a-4e4f-8dee-d381e843f30b)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->


## PR Pointers

- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL".
- Never force push. If you do, your PR will be closed.
